### PR TITLE
Fix gpg options

### DIFF
--- a/tests/00-test-setup-gpg.sh
+++ b/tests/00-test-setup-gpg.sh
@@ -3,8 +3,8 @@ source tests/setup/helpers.sh
 
 can_encrypt_and_decrypt_with_the_test_key() {
     echo "hello" \
-        | gpg --encrypt -r "$GPG_ID" "$GPG_OPTS" \
-        | gpg --decrypt "$GPG_OPTS" 2>"$LOG_FILE" \
+        | gpg --encrypt -r "$GPG_ID" "${GPG_OPTS[@]}" \
+        | gpg --decrypt "${GPG_OPTS[@]}" 2>"$LOG_FILE" \
         | grep "hello" >"$LOG_FILE"
 }
 

--- a/tests/setup/helpers.sh
+++ b/tests/setup/helpers.sh
@@ -7,14 +7,14 @@ TESTS="$(pwd)/tests"
 # gpg
 
 GNUPGHOME=./tests/.gpg
-GPG_OPTS="--passphrase=passphrase --batch --pinentry-mode loopback"
+GPG_OPTS=("--passphrase=passphrase" "--batch" "--pinentry-mode" "loopback")
 GPG_ID=foo@bar.com
 export GNUPGHOME GPG_OPTS GPG_ID
 
 # pass store
 
 PASSWORD_STORE_DIR=$(mktemp -d -t pass-index-XXXXXXXX)
-PASSWORD_STORE_GPG_OPTS=$GPG_OPTS
+PASSWORD_STORE_GPG_OPTS=${GPG_OPTS[*]}
 PASSWORD_STORE_EXTENSIONS_DIR=$TESTS/../bin
 PASSWORD_STORE_ENABLE_EXTENSIONS=true
 PASSWORD_STORE_CLIP_TIME=2
@@ -49,7 +49,7 @@ tests_run=0
 
 dump_info() {
     echo "dump:"
-    echo "  GPG_OPTS=$GPG_OPTS"
+    echo "  GPG_OPTS=${GPG_OPTS[*]}"
     echo "  GNUPGHOME=$(realpath "$GNUPGHOME")"
     echo "  PASSWORD_STORE_DIR=$PASSWORD_STORE_DIR"
     echo "  PASSWORD_STORE_EXTENSIONS_DIR=$(realpath "$PASSWORD_STORE_EXTENSIONS_DIR")"

--- a/tests/setup/helpers.sh
+++ b/tests/setup/helpers.sh
@@ -54,6 +54,9 @@ dump_info() {
     echo "  PASSWORD_STORE_DIR=$PASSWORD_STORE_DIR"
     echo "  PASSWORD_STORE_EXTENSIONS_DIR=$(realpath "$PASSWORD_STORE_EXTENSIONS_DIR")"
 
+    echo "  logfile:"
+    sed  's/^/    /' < "$LOG_FILE"
+
     echo "files in store directory:"
     find "$PASSWORD_STORE_DIR" -type f -print0 | xargs -0 -Iname echo "  name"
 }

--- a/tests/setup/init-test-gpg.sh
+++ b/tests/setup/init-test-gpg.sh
@@ -3,7 +3,7 @@ set -e
 
 # setup a test gpg home directory and create a secret key
 # based on https://gist.github.com/pretorh/0a4a8192e0b8e8c9a7b574ec1c824224
-GNUPGHOME=$1
+GNUPGHOME=${1-./tests/.gpg}
 export GNUPGHOME
 
 rm -rf "$GNUPGHOME"
@@ -15,3 +15,5 @@ Key-Type: RSA
 Name-Email: foo@bar.com
 Passphrase:passphrase
 EOF
+
+gpg --check-trustdb


### PR DESCRIPTION
change test's `GPG_OPTS` to array, pass array in gpg test, use concatenated string for `PASSWORD_STORE_GPG_OPTS`

minor test helpers (dump log file on test failure, add default path in `tests/setup/init-test-gpg.sh` script)

fixes #2 