### PR TITLE
tests: add fake xclip, pbcopy

### DIFF
--- a/tests/21-create-generated-password.sh
+++ b/tests/21-create-generated-password.sh
@@ -13,10 +13,10 @@ can_generate_the_password() {
 
 can_copy_to_clipboard() {
     echo "passname2" | \
-        PASS_INDEX_UUID_GENERATOR="echo uuid2" pass index create --generate 64 --clip
+        PASS_INDEX_UUID_GENERATOR="echo uuid2" pass index create --generate 64 --clip 2>"$LOG_FILE"
 
     clipboard=$(paste_from_clipboard)
-    echo "$clipboard" | grep -E "^.{64}$" >"$LOG_FILE" \
+    echo "$clipboard" | grep -E "^.{64}$" >>"$LOG_FILE" \
         || fail "password not found in clipboard" "$clipboard"
 }
 

--- a/tests/30-reading.sh
+++ b/tests/30-reading.sh
@@ -42,10 +42,10 @@ ls_command_can_grep() {
 }
 
 can_copy_password_to_clipboard() {
-    echo "example.com" | pass index show --clip
+    echo "example.com" | pass index show --clip 2>"$LOG_FILE"
 
     pasted="$(paste_from_clipboard)"
-    echo "$pasted" | grep "^password for test$" >"$LOG_FILE" \
+    echo "$pasted" | grep "^password for test$" >>"$LOG_FILE" \
         || fail "did not copy password to clipboard" "$pasted"
 }
 

--- a/tests/fake/clip-to-file.sh
+++ b/tests/fake/clip-to-file.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set +e # *not* -e
+
+echo "fake $(basename "$0") (write to $CLIP_FILE)" >&2
+read -r value
+echo "$value" > "$CLIP_FILE"

--- a/tests/fake/pbcopy
+++ b/tests/fake/pbcopy
@@ -1,0 +1,1 @@
+clip-to-file.sh

--- a/tests/fake/xclip
+++ b/tests/fake/xclip
@@ -1,0 +1,1 @@
+clip-to-file.sh

--- a/tests/setup/helpers.sh
+++ b/tests/setup/helpers.sh
@@ -27,7 +27,9 @@ export PASS_INDEX_SILENT
 
 # helpers
 LOG_FILE=$PASSWORD_STORE_DIR/tests.log
-export LOG_FILE
+CLIP_FILE=$PASSWORD_STORE_DIR/clipboard.log
+PATH="./tests/fake:$PATH"
+export LOG_FILE CLIP_FILE PATH DISPLAY
 
 init_password_store() {
     pass init $GPG_ID >"$LOG_FILE"
@@ -90,10 +92,11 @@ fail() {
 }
 
 paste_from_clipboard() {
-    if [ "$(uname)" = "Darwin" ] ; then
-        pbpaste
+    echo "reading from fake clip file $CLIP_FILE" >>"$LOG_FILE"
+    if [ -f "$CLIP_FILE" ] ; then
+        cat "$CLIP_FILE"
     else
-        xclip -out -selection clipboard
+        echo -n ""
     fi
 }
 

--- a/tests/setup/helpers.sh
+++ b/tests/setup/helpers.sh
@@ -29,7 +29,7 @@ export PASS_INDEX_SILENT
 LOG_FILE=$PASSWORD_STORE_DIR/tests.log
 CLIP_FILE=$PASSWORD_STORE_DIR/clipboard.log
 PATH="./tests/fake:$PATH"
-export LOG_FILE CLIP_FILE PATH DISPLAY
+export LOG_FILE CLIP_FILE PATH
 
 init_password_store() {
     pass init $GPG_ID >"$LOG_FILE"


### PR DESCRIPTION
add fake clip helpers that read from stdin and write to `CLIP_FILE` (set in helpers)

change helper's `paste_from_clipboard` to read from this file

this will simplify ci setup (no xclip/display issues)